### PR TITLE
tweak control flow

### DIFF
--- a/parser/demo/control-flow.txt
+++ b/parser/demo/control-flow.txt
@@ -1,5 +1,19 @@
 if blah == 5 {return 5}
 
+let x = {
+    let z = label1@{
+        if blah {
+            return @label1 5
+        } else if foo {
+            { 1 } + { 5 }
+        } else {
+            return -1
+        }
+    }
+
+    return z + 1
+}
+
 let x = { return 5} + {return 3}
 
 if i > 5 {

--- a/parser/demo/main.go
+++ b/parser/demo/main.go
@@ -10,18 +10,22 @@ import (
 )
 
 func main() {
-	content, err := ioutil.ReadFile(os.Args[1])
-	if err != nil {
-		panic(err)
-	}
+	for _, path := range os.Args[1:] {
+		fmt.Println(path, "===========================")
 
-	parsed, err := parser.Parse(os.Args[1], bytes.NewReader(content))
-	if err != nil {
-		panic(err)
-	}
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			panic(err)
+		}
 
-	fmt.Println("OK")
-	for _, node := range parsed {
-		fmt.Println(node)
+		parsed, err := parser.Parse(path, bytes.NewReader(content))
+		if err != nil {
+			panic(err)
+		}
+
+		for _, node := range parsed {
+			fmt.Println(node)
+		}
+		fmt.Println("OK")
 	}
 }

--- a/parser/demo/test.txt
+++ b/parser/demo/test.txt
@@ -33,7 +33,7 @@ let a = false
     ||
     0 < x < 7
 
-let z = a.b.c * (0 + 0xDeadBeef) / - 01234567 * 123 *
+let z = a.b.c * {0 + 0xDeadBeef} / - 01234567 * 123 *
         17. /*
                 /* scoped block */ comment
 

--- a/parser/parse_tree.go
+++ b/parser/parse_tree.go
@@ -317,20 +317,6 @@ func (accessor *Accessor) String() string {
 	return prettyFormatNode("", accessor, 0)
 }
 
-// ( <expression> )
-type EvalOrderExpr struct {
-	Location
-	expr
-
-	LParen     *Token
-	Expression Expr
-	RParen     *Token
-}
-
-func (evalOrder *EvalOrderExpr) String() string {
-	return prettyFormatNode("", evalOrder, 0)
-}
-
 // Placeholder for comments at the end of file
 type Noop struct {
 	Location
@@ -347,6 +333,8 @@ type ExprBlock struct {
 	Location
 	controlFlowExpr
 
+	Label      *Token
+	At         *Token
 	LBrace     *Token
 	Statements []ControlFlowExpr
 	RBrace     *Token
@@ -371,6 +359,18 @@ func (cond *ConditionalExpr) String() string {
 	return prettyFormatNode("", cond, 0)
 }
 
+// <expr>
+type EvalExpr struct {
+	Location
+	controlFlowExpr
+
+	Expression Expr
+}
+
+func (eval *EvalExpr) String() string {
+	return prettyFormatNode("", eval, 0)
+}
+
 // let <name> = <expr>
 type AssignExpr struct {
 	Location
@@ -391,6 +391,7 @@ type ReturnExpr struct {
 	controlFlowExpr
 
 	Return     *Token
+	At         *Token // Optional
 	Label      *Token // Optional
 	Expression Expr
 }

--- a/parser/ql.go
+++ b/parser/ql.go
@@ -32,39 +32,40 @@ const COLON = 57356
 const COMMA = 57357
 const DOT = 57358
 const STAR_STAR = 57359
-const SEMICOLON = 57360
-const NEWLINE = 57361
-const LET = 57362
-const IF = 57363
-const ELSE = 57364
-const RETURN = 57365
-const OR = 57366
-const AND = 57367
-const NOT = 57368
-const LT = 57369
-const GT = 57370
-const EQ = 57371
-const NE = 57372
-const LE = 57373
-const GE = 57374
-const BITWISE_OR = 57375
-const BITWISE_AND = 57376
-const XOR = 57377
-const L_SHIFT = 57378
-const R_SHIFT = 57379
-const ADD = 57380
-const SUB = 57381
-const MUL = 57382
-const DIV = 57383
-const MOD = 57384
-const UNARY = 57385
-const IDENT = 57386
-const CHAR = 57387
-const STRING = 57388
-const INT = 57389
-const FLOAT = 57390
-const BOOL = 57391
-const NOOP = 57392
+const AT = 57360
+const SEMICOLON = 57361
+const NEWLINE = 57362
+const LET = 57363
+const IF = 57364
+const ELSE = 57365
+const RETURN = 57366
+const OR = 57367
+const AND = 57368
+const NOT = 57369
+const LT = 57370
+const GT = 57371
+const EQ = 57372
+const NE = 57373
+const LE = 57374
+const GE = 57375
+const BITWISE_OR = 57376
+const BITWISE_AND = 57377
+const XOR = 57378
+const L_SHIFT = 57379
+const R_SHIFT = 57380
+const ADD = 57381
+const SUB = 57382
+const MUL = 57383
+const DIV = 57384
+const MOD = 57385
+const UNARY = 57386
+const IDENT = 57387
+const CHAR = 57388
+const STRING = 57389
+const INT = 57390
+const FLOAT = 57391
+const BOOL = 57392
+const NOOP = 57393
 
 var qlToknames = [...]string{
 	"$end",
@@ -84,6 +85,7 @@ var qlToknames = [...]string{
 	"COMMA",
 	"DOT",
 	"STAR_STAR",
+	"AT",
 	"SEMICOLON",
 	"NEWLINE",
 	"LET",
@@ -124,7 +126,7 @@ const qlEofCode = 1
 const qlErrCode = 2
 const qlInitialStackSize = 16
 
-//line ql.y:607
+//line ql.y:628
 
 //line yacctab:1
 var qlExca = [...]int{
@@ -135,60 +137,60 @@ var qlExca = [...]int{
 
 const qlPrivate = 57344
 
-const qlLast = 259
+const qlLast = 244
 
 var qlAct = [...]int{
 
-	35, 84, 34, 11, 48, 49, 50, 51, 52, 53,
-	54, 55, 56, 57, 33, 92, 21, 55, 56, 57,
-	64, 36, 7, 8, 60, 61, 51, 52, 53, 54,
-	55, 56, 57, 62, 53, 54, 55, 56, 57, 94,
-	63, 66, 67, 68, 69, 70, 71, 72, 73, 74,
-	75, 76, 77, 78, 79, 80, 81, 82, 83, 14,
-	87, 31, 10, 59, 2, 10, 89, 36, 90, 93,
-	58, 37, 14, 15, 5, 86, 10, 14, 85, 20,
-	4, 19, 14, 38, 18, 1, 13, 12, 7, 8,
-	16, 15, 6, 17, 39, 97, 95, 3, 22, 40,
-	41, 65, 42, 43, 44, 45, 46, 47, 48, 49,
-	50, 51, 52, 53, 54, 55, 56, 57, 88, 0,
-	9, 0, 0, 0, 0, 0, 91, 0, 0, 0,
-	0, 0, 40, 41, 0, 42, 43, 44, 45, 46,
-	47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-	57, 0, 40, 41, 96, 42, 43, 44, 45, 46,
-	47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-	57, 14, 0, 32, 50, 51, 52, 53, 54, 55,
-	56, 57, 14, 0, 32, 15, 0, 0, 0, 0,
-	24, 49, 50, 51, 52, 53, 54, 55, 56, 57,
-	0, 24, 0, 23, 0, 0, 0, 0, 25, 26,
-	27, 28, 29, 30, 23, 0, 0, 0, 0, 25,
-	26, 27, 28, 29, 30, 41, 0, 42, 43, 44,
-	45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
-	55, 56, 57, 42, 43, 44, 45, 46, 47, 48,
-	49, 50, 51, 52, 53, 54, 55, 56, 57,
+	13, 27, 14, 46, 47, 48, 10, 39, 40, 41,
+	42, 43, 44, 45, 46, 47, 48, 28, 98, 54,
+	55, 56, 2, 50, 41, 42, 43, 44, 45, 46,
+	47, 48, 59, 60, 61, 62, 63, 64, 65, 66,
+	67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
+	79, 58, 78, 49, 82, 85, 31, 32, 83, 33,
+	34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+	44, 45, 46, 47, 48, 92, 28, 57, 28, 44,
+	45, 46, 47, 48, 88, 89, 93, 7, 8, 51,
+	28, 20, 95, 20, 97, 96, 91, 77, 19, 53,
+	101, 100, 7, 8, 15, 20, 52, 16, 90, 94,
+	19, 18, 99, 87, 85, 86, 21, 22, 23, 24,
+	25, 26, 28, 18, 81, 80, 1, 12, 21, 22,
+	23, 24, 25, 26, 9, 84, 11, 6, 3, 17,
+	31, 32, 28, 33, 34, 35, 36, 37, 38, 39,
+	40, 41, 42, 43, 44, 45, 46, 47, 48, 28,
+	85, 0, 19, 40, 41, 42, 43, 44, 45, 46,
+	47, 48, 4, 0, 20, 18, 29, 0, 0, 19,
+	21, 22, 23, 24, 25, 26, 5, 0, 0, 0,
+	0, 0, 18, 30, 0, 0, 0, 21, 22, 23,
+	24, 25, 26, 32, 0, 33, 34, 35, 36, 37,
+	38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+	48, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+	42, 43, 44, 45, 46, 47, 48, 42, 43, 44,
+	45, 46, 47, 48,
 }
 var qlPact = [...]int{
 
-	70, -1000, -1000, 70, -1000, -1000, 4, -1000, -1000, -1000,
-	-1000, -1000, -1000, -1000, 70, 175, -30, 164, -1000, -1000,
-	63, 75, 54, 175, 175, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, 175, 27, -1000, 128, -1000, -1000, -2, 65,
-	175, 175, 175, 175, 175, 175, 175, 175, 175, 175,
-	175, 175, 175, 175, 175, 175, 175, 175, -43, 175,
-	-1000, 216, 108, 164, 52, -7, 200, 216, -29, -29,
-	-29, -29, -29, -29, 157, 139, -10, -4, -4, -23,
-	-23, -1000, -1000, -1000, -1000, 59, 24, 128, -1000, -1000,
-	-1000, -1000, 52, -1000, 175, -1000, -1000, 128,
+	83, -1000, -1000, 83, -1000, -1000, 68, -1000, -1000, -1000,
+	-1000, -1000, -1000, 31, -1000, 8, 71, 90, 135, 135,
+	135, 59, -1000, -1000, -1000, -1000, -1000, -1000, 83, -1000,
+	-1000, 135, 135, 135, 135, 135, 135, 135, 135, 135,
+	135, 135, 135, 135, 135, 135, 135, 135, 135, 84,
+	-1000, 7, 5, 135, -1000, 193, 115, 108, 105, 177,
+	193, -27, -27, -27, -27, -27, -27, 128, -12, 200,
+	40, 40, -38, -38, -1000, -1000, -1000, 152, 152, -1000,
+	98, 81, 31, 52, 10, 59, 83, -1000, -1000, -1000,
+	-1000, 135, 69, -5, 104, 31, -1000, -1000, 69, -1000,
+	-1000, -1000,
 }
 var qlPgo = [...]int{
 
-	0, 2, 98, 0, 64, 97, 80, 92, 61, 3,
-	87, 86, 85, 74, 78, 75,
+	0, 6, 139, 0, 22, 138, 172, 137, 1, 2,
+	136, 127, 126, 186, 125, 124,
 }
 var qlR1 = [...]int{
 
 	0, 12, 4, 4, 5, 5, 13, 13, 6, 6,
-	7, 7, 7, 7, 7, 8, 9, 9, 9, 9,
-	9, 9, 10, 11, 1, 1, 2, 2, 2, 2,
+	7, 7, 7, 7, 8, 8, 9, 9, 9, 9,
+	9, 9, 10, 11, 11, 1, 1, 2, 2, 2,
 	2, 2, 2, 2, 2, 2, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 14, 14, 15,
@@ -197,38 +199,40 @@ var qlR1 = [...]int{
 var qlR2 = [...]int{
 
 	0, 1, 0, 1, 1, 2, 1, 1, 1, 2,
-	1, 1, 1, 1, 1, 3, 3, 4, 5, 6,
-	5, 6, 4, 2, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 3, 4, 3, 1, 3, 3, 3,
+	1, 1, 1, 1, 3, 5, 3, 4, 5, 6,
+	5, 6, 4, 2, 4, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 3, 4, 1, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 2, 2, 0, 1, 1,
 	3,
 }
 var qlChk = [...]int{
 
-	-1000, -12, -4, -5, -6, -13, -7, 18, 19, 50,
-	-8, -9, -10, -11, 7, 21, 20, 23, -6, -13,
-	-4, -3, -2, 39, 26, 44, 45, 46, 47, 48,
-	49, -8, 9, 44, -1, -3, -9, 8, -8, 19,
-	24, 25, 27, 28, 29, 30, 31, 32, 33, 34,
-	35, 36, 37, 38, 39, 40, 41, 42, 16, 9,
-	-3, -3, -3, 13, 22, -8, -3, -3, -3, -3,
+	-1000, -12, -4, -5, -6, -13, -7, 19, 20, 51,
+	-1, -10, -11, -3, -9, 21, 24, -2, 40, 27,
+	22, 45, 46, 47, 48, 49, 50, -8, 7, -6,
+	-13, 25, 26, 28, 29, 30, 31, 32, 33, 34,
+	35, 36, 37, 38, 39, 40, 41, 42, 43, 45,
+	-1, 18, 16, 9, -3, -3, -3, 18, -4, -3,
 	-3, -3, -3, -3, -3, -3, -3, -3, -3, -3,
-	-3, -3, -3, -3, 44, -14, -15, -3, 10, -1,
-	-9, -8, 22, 10, 15, -9, -8, -3,
+	-3, -3, -3, -3, -3, -3, -3, 13, 45, 45,
+	-14, -15, -3, -8, 20, 45, 7, 8, -1, -1,
+	10, 15, 23, -8, -4, -3, -9, -8, 23, 8,
+	-9, -8,
 }
 var qlDef = [...]int{
 
 	2, -2, 1, 3, 4, 8, 0, 6, 7, 10,
-	11, 12, 13, 14, 2, 0, 0, 0, 5, 9,
-	0, 0, 36, 0, 0, 26, 27, 28, 29, 30,
-	31, 32, 0, 0, 23, 24, 25, 15, 16, 0,
+	11, 12, 13, 25, 26, 0, 0, 36, 0, 0,
+	0, 27, 28, 29, 30, 31, 32, 33, 2, 5,
+	9, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 57,
-	55, 56, 0, 0, 0, 17, 37, 38, 39, 40,
-	41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-	51, 52, 53, 54, 33, 0, 58, 59, 35, 22,
-	18, 20, 0, 34, 0, 19, 21, 60,
+	23, 0, 0, 57, 55, 56, 0, 0, 0, 37,
+	38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+	48, 49, 50, 51, 52, 53, 54, 0, 0, 34,
+	0, 58, 59, 16, 0, 0, 2, 14, 22, 24,
+	35, 0, 0, 17, 0, 60, 18, 20, 0, 15,
+	19, 21,
 }
 var qlTok1 = [...]int{
 
@@ -240,7 +244,7 @@ var qlTok2 = [...]int{
 	12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
 	22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
 	32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
-	42, 43, 44, 45, 46, 47, 48, 49, 50,
+	42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
 }
 var qlTok3 = [...]int{
 	0,
@@ -621,20 +625,33 @@ qldefault:
 				qlVAL.Statements = append(qlDollar[1].Statements, qlDollar[2].ControlFlowExpr)
 			}
 		}
+	case 6:
+		qlDollar = qlS[qlpt-1 : qlpt+1]
+//line ql.y:107
+		{
+			// do nothing
+		}
+	case 7:
+		qlDollar = qlS[qlpt-1 : qlpt+1]
+//line ql.y:110
+		{
+			// do nothing
+		}
 	case 8:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:112
+//line ql.y:116
 		{
 			qlVAL.ControlFlowExpr = nil
 		}
 	case 9:
 		qlDollar = qlS[qlpt-2 : qlpt+1]
-//line ql.y:115
+//line ql.y:119
 		{
+			qlVAL.ControlFlowExpr = qlDollar[1].ControlFlowExpr
 		}
 	case 10:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:120
+//line ql.y:125
 		{
 			qlVAL.ControlFlowExpr = &Noop{
 				Location: qlDollar[1].Token.Location,
@@ -643,31 +660,28 @@ qldefault:
 		}
 	case 11:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:126
+//line ql.y:131
 		{
-			qlVAL.ControlFlowExpr = qlDollar[1].ControlFlowExpr
+			qlVAL.ControlFlowExpr = &EvalExpr{
+				Location:   qlDollar[1].Expr.Loc(),
+				Expression: qlDollar[1].Expr,
+			}
 		}
 	case 12:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:129
+//line ql.y:137
 		{
 			qlVAL.ControlFlowExpr = qlDollar[1].ControlFlowExpr
 		}
 	case 13:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:132
+//line ql.y:140
 		{
 			qlVAL.ControlFlowExpr = qlDollar[1].ControlFlowExpr
 		}
 	case 14:
-		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:135
-		{
-			qlVAL.ControlFlowExpr = qlDollar[1].ControlFlowExpr
-		}
-	case 15:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:142
+//line ql.y:146
 		{
 			qlVAL.ControlFlowExpr = &ExprBlock{
 				Location: Location{
@@ -680,9 +694,26 @@ qldefault:
 				RBrace:     qlDollar[3].Token,
 			}
 		}
+	case 15:
+		qlDollar = qlS[qlpt-5 : qlpt+1]
+//line ql.y:158
+		{
+			qlVAL.ControlFlowExpr = &ExprBlock{
+				Location: Location{
+					Filename: qlDollar[1].Token.Loc().Filename,
+					Start:    qlDollar[1].Token.Loc().Start,
+					End:      qlDollar[5].Token.Loc().End,
+				},
+				Label:      qlDollar[1].Token,
+				At:         qlDollar[2].Token,
+				LBrace:     qlDollar[3].Token,
+				Statements: qlDollar[4].Statements,
+				RBrace:     qlDollar[5].Token,
+			}
+		}
 	case 16:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:157
+//line ql.y:175
 		{
 			qlVAL.ControlFlowExpr = &ConditionalExpr{
 				Location: Location{
@@ -697,7 +728,7 @@ qldefault:
 		}
 	case 17:
 		qlDollar = qlS[qlpt-4 : qlpt+1]
-//line ql.y:169
+//line ql.y:187
 		{
 			qlVAL.ControlFlowExpr = &ConditionalExpr{
 				Location: Location{
@@ -712,7 +743,7 @@ qldefault:
 		}
 	case 18:
 		qlDollar = qlS[qlpt-5 : qlpt+1]
-//line ql.y:181
+//line ql.y:199
 		{
 			qlVAL.ControlFlowExpr = &ConditionalExpr{
 				Location: Location{
@@ -729,7 +760,7 @@ qldefault:
 		}
 	case 19:
 		qlDollar = qlS[qlpt-6 : qlpt+1]
-//line ql.y:195
+//line ql.y:213
 		{
 			qlVAL.ControlFlowExpr = &ConditionalExpr{
 				Location: Location{
@@ -746,7 +777,7 @@ qldefault:
 		}
 	case 20:
 		qlDollar = qlS[qlpt-5 : qlpt+1]
-//line ql.y:209
+//line ql.y:227
 		{
 			qlVAL.ControlFlowExpr = &ConditionalExpr{
 				Location: Location{
@@ -763,7 +794,7 @@ qldefault:
 		}
 	case 21:
 		qlDollar = qlS[qlpt-6 : qlpt+1]
-//line ql.y:223
+//line ql.y:241
 		{
 			qlVAL.ControlFlowExpr = &ConditionalExpr{
 				Location: Location{
@@ -780,7 +811,7 @@ qldefault:
 		}
 	case 22:
 		qlDollar = qlS[qlpt-4 : qlpt+1]
-//line ql.y:240
+//line ql.y:258
 		{
 			qlVAL.ControlFlowExpr = &AssignExpr{
 				Location: Location{
@@ -796,7 +827,7 @@ qldefault:
 		}
 	case 23:
 		qlDollar = qlS[qlpt-2 : qlpt+1]
-//line ql.y:257
+//line ql.y:274
 		{
 			qlVAL.ControlFlowExpr = &ReturnExpr{
 				Location: Location{
@@ -809,38 +840,45 @@ qldefault:
 			}
 		}
 	case 24:
-		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:271
+		qlDollar = qlS[qlpt-4 : qlpt+1]
+//line ql.y:285
 		{
-			qlVAL.Expr = qlDollar[1].Expr
+			qlVAL.ControlFlowExpr = &ReturnExpr{
+				Location: Location{
+					Filename: qlDollar[1].Token.Loc().Filename,
+					Start:    qlDollar[1].Token.Loc().Start,
+					End:      qlDollar[3].Token.Loc().End,
+				},
+				Return:     qlDollar[1].Token,
+				At:         qlDollar[2].Token,
+				Label:      qlDollar[3].Token,
+				Expression: qlDollar[4].Expr,
+			}
 		}
 	case 25:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:274
+//line ql.y:301
 		{
-			qlVAL.Expr = qlDollar[1].ControlFlowExpr
+			qlVAL.Expr = qlDollar[1].Expr
 		}
 	case 26:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:281
+//line ql.y:304
+		{
+			qlVAL.Expr = qlDollar[1].ControlFlowExpr
+		}
+	case 27:
+		qlDollar = qlS[qlpt-1 : qlpt+1]
+//line ql.y:311
 		{
 			qlVAL.Expr = &Identifier{
 				Location: qlDollar[1].Token.Location,
 				Value:    qlDollar[1].Token,
 			}
 		}
-	case 27:
-		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:287
-		{
-			qlVAL.Expr = &Literal{
-				Location: qlDollar[1].Token.Location,
-				Value:    qlDollar[1].Token,
-			}
-		}
 	case 28:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:293
+//line ql.y:317
 		{
 			qlVAL.Expr = &Literal{
 				Location: qlDollar[1].Token.Location,
@@ -849,7 +887,7 @@ qldefault:
 		}
 	case 29:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:299
+//line ql.y:323
 		{
 			qlVAL.Expr = &Literal{
 				Location: qlDollar[1].Token.Location,
@@ -858,7 +896,7 @@ qldefault:
 		}
 	case 30:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:305
+//line ql.y:329
 		{
 			qlVAL.Expr = &Literal{
 				Location: qlDollar[1].Token.Location,
@@ -867,7 +905,7 @@ qldefault:
 		}
 	case 31:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:311
+//line ql.y:335
 		{
 			qlVAL.Expr = &Literal{
 				Location: qlDollar[1].Token.Location,
@@ -876,13 +914,22 @@ qldefault:
 		}
 	case 32:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:317
+//line ql.y:341
+		{
+			qlVAL.Expr = &Literal{
+				Location: qlDollar[1].Token.Location,
+				Value:    qlDollar[1].Token,
+			}
+		}
+	case 33:
+		qlDollar = qlS[qlpt-1 : qlpt+1]
+//line ql.y:347
 		{
 			qlVAL.Expr = qlDollar[1].ControlFlowExpr
 		}
-	case 33:
+	case 34:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:320
+//line ql.y:350
 		{
 			qlVAL.Expr = &Accessor{
 				Location: Location{
@@ -895,35 +942,20 @@ qldefault:
 				Name:        qlDollar[3].Token,
 			}
 		}
-	case 34:
-		qlDollar = qlS[qlpt-4 : qlpt+1]
-//line ql.y:332
-		{
-		}
 	case 35:
-		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:334
+		qlDollar = qlS[qlpt-4 : qlpt+1]
+//line ql.y:362
 		{
-			qlVAL.Expr = &EvalOrderExpr{
-				Location: Location{
-					Filename: qlDollar[1].Token.Loc().Filename,
-					Start:    qlDollar[1].Token.Loc().Start,
-					End:      qlDollar[3].Token.Loc().End,
-				},
-				LParen:     qlDollar[1].Token,
-				Expression: qlDollar[2].Expr,
-				RParen:     qlDollar[3].Token,
-			}
 		}
 	case 36:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:350
+//line ql.y:368
 		{
 			qlVAL.Expr = qlDollar[1].Expr
 		}
 	case 37:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:353
+//line ql.y:371
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -938,7 +970,7 @@ qldefault:
 		}
 	case 38:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:365
+//line ql.y:383
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -953,7 +985,7 @@ qldefault:
 		}
 	case 39:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:377
+//line ql.y:395
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -968,7 +1000,7 @@ qldefault:
 		}
 	case 40:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:389
+//line ql.y:407
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -983,7 +1015,7 @@ qldefault:
 		}
 	case 41:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:401
+//line ql.y:419
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -998,7 +1030,7 @@ qldefault:
 		}
 	case 42:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:413
+//line ql.y:431
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1013,7 +1045,7 @@ qldefault:
 		}
 	case 43:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:425
+//line ql.y:443
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1028,7 +1060,7 @@ qldefault:
 		}
 	case 44:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:437
+//line ql.y:455
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1043,7 +1075,7 @@ qldefault:
 		}
 	case 45:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:449
+//line ql.y:467
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1058,7 +1090,7 @@ qldefault:
 		}
 	case 46:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:461
+//line ql.y:479
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1073,7 +1105,7 @@ qldefault:
 		}
 	case 47:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:473
+//line ql.y:491
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1088,7 +1120,7 @@ qldefault:
 		}
 	case 48:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:485
+//line ql.y:503
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1103,7 +1135,7 @@ qldefault:
 		}
 	case 49:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:497
+//line ql.y:515
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1118,7 +1150,7 @@ qldefault:
 		}
 	case 50:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:509
+//line ql.y:527
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1133,7 +1165,7 @@ qldefault:
 		}
 	case 51:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:521
+//line ql.y:539
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1148,7 +1180,7 @@ qldefault:
 		}
 	case 52:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:533
+//line ql.y:551
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1163,7 +1195,7 @@ qldefault:
 		}
 	case 53:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:545
+//line ql.y:563
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1178,7 +1210,7 @@ qldefault:
 		}
 	case 54:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:557
+//line ql.y:575
 		{
 			qlVAL.Expr = &BinaryExpr{
 				Location: Location{
@@ -1193,7 +1225,7 @@ qldefault:
 		}
 	case 55:
 		qlDollar = qlS[qlpt-2 : qlpt+1]
-//line ql.y:569
+//line ql.y:587
 		{
 			qlVAL.Expr = &UnaryExpr{
 				Location: Location{
@@ -1207,7 +1239,7 @@ qldefault:
 		}
 	case 56:
 		qlDollar = qlS[qlpt-2 : qlpt+1]
-//line ql.y:580
+//line ql.y:598
 		{
 			qlVAL.Expr = &UnaryExpr{
 				Location: Location{
@@ -1221,23 +1253,26 @@ qldefault:
 		}
 	case 57:
 		qlDollar = qlS[qlpt-0 : qlpt+1]
-//line ql.y:594
+//line ql.y:612
 		{ // empty
 		}
 	case 58:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:596
+//line ql.y:614
 		{
+			// TODO
 		}
 	case 59:
 		qlDollar = qlS[qlpt-1 : qlpt+1]
-//line ql.y:601
+//line ql.y:620
 		{
+			// TODO
 		}
 	case 60:
 		qlDollar = qlS[qlpt-3 : qlpt+1]
-//line ql.y:603
+//line ql.y:623
 		{
+			// TODO
 		}
 	}
 	goto qlstack /* stack new state and value */

--- a/parser/ql.output
+++ b/parser/ql.output
@@ -3,23 +3,34 @@ state 0
 	$accept: .start $end 
 	statement_list: .    (2)
 
-	L_BRACE  shift 14
+	L_BRACE  shift 28
 	SEMICOLON  shift 7
 	NEWLINE  shift 8
-	LET  shift 16
-	IF  shift 15
-	RETURN  shift 17
+	LET  shift 15
+	IF  shift 20
+	RETURN  shift 16
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
 	NOOP  shift 9
 	.  reduce 2 (src line 83)
 
+	expr  goto 10
+	unit_expr  goto 17
+	composable_expr  goto 13
 	statement_list  goto 2
 	nonempty_statement_list  goto 3
 	statement  goto 4
 	control_flow_expr  goto 6
-	expr_block  goto 10
-	conditional_expr  goto 11
-	assignment_expr  goto 12
-	return_expr  goto 13
+	expr_block  goto 27
+	conditional_expr  goto 14
+	assignment_expr  goto 11
+	return_expr  goto 12
 	start  goto 1
 	terminator  goto 5
 
@@ -40,21 +51,32 @@ state 3
 	statement_list:  nonempty_statement_list.    (3)
 	nonempty_statement_list:  nonempty_statement_list.statement 
 
-	L_BRACE  shift 14
+	L_BRACE  shift 28
 	SEMICOLON  shift 7
 	NEWLINE  shift 8
-	LET  shift 16
-	IF  shift 15
-	RETURN  shift 17
+	LET  shift 15
+	IF  shift 20
+	RETURN  shift 16
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
 	NOOP  shift 9
 	.  reduce 3 (src line 87)
 
-	statement  goto 18
+	expr  goto 10
+	unit_expr  goto 17
+	composable_expr  goto 13
+	statement  goto 29
 	control_flow_expr  goto 6
-	expr_block  goto 10
-	conditional_expr  goto 11
-	assignment_expr  goto 12
-	return_expr  goto 13
+	expr_block  goto 27
+	conditional_expr  goto 14
+	assignment_expr  goto 11
+	return_expr  goto 12
 	terminator  goto 5
 
 state 4
@@ -66,7 +88,7 @@ state 4
 state 5
 	statement:  terminator.    (8)
 
-	.  reduce 8 (src line 111)
+	.  reduce 8 (src line 115)
 
 
 state 6
@@ -76,7 +98,7 @@ state 6
 	NEWLINE  shift 8
 	.  error
 
-	terminator  goto 19
+	terminator  goto 30
 
 state 7
 	terminator:  SEMICOLON.    (6)
@@ -87,63 +109,158 @@ state 7
 state 8
 	terminator:  NEWLINE.    (7)
 
-	.  reduce 7 (src line 108)
+	.  reduce 7 (src line 110)
 
 
 state 9
 	control_flow_expr:  NOOP.    (10)
 
-	.  reduce 10 (src line 119)
+	.  reduce 10 (src line 124)
 
 
 state 10
-	control_flow_expr:  expr_block.    (11)
+	control_flow_expr:  expr.    (11)
 
-	.  reduce 11 (src line 126)
+	.  reduce 11 (src line 131)
 
 
 state 11
-	control_flow_expr:  conditional_expr.    (12)
+	control_flow_expr:  assignment_expr.    (12)
 
-	.  reduce 12 (src line 129)
+	.  reduce 12 (src line 137)
 
 
 state 12
-	control_flow_expr:  assignment_expr.    (13)
+	control_flow_expr:  return_expr.    (13)
 
-	.  reduce 13 (src line 132)
+	.  reduce 13 (src line 140)
 
 
 state 13
-	control_flow_expr:  return_expr.    (14)
+	expr:  composable_expr.    (25)
+	composable_expr:  composable_expr.OR composable_expr 
+	composable_expr:  composable_expr.AND composable_expr 
+	composable_expr:  composable_expr.LT composable_expr 
+	composable_expr:  composable_expr.GT composable_expr 
+	composable_expr:  composable_expr.EQ composable_expr 
+	composable_expr:  composable_expr.NE composable_expr 
+	composable_expr:  composable_expr.LE composable_expr 
+	composable_expr:  composable_expr.GE composable_expr 
+	composable_expr:  composable_expr.BITWISE_OR composable_expr 
+	composable_expr:  composable_expr.BITWISE_AND composable_expr 
+	composable_expr:  composable_expr.XOR composable_expr 
+	composable_expr:  composable_expr.L_SHIFT composable_expr 
+	composable_expr:  composable_expr.R_SHIFT composable_expr 
+	composable_expr:  composable_expr.ADD composable_expr 
+	composable_expr:  composable_expr.SUB composable_expr 
+	composable_expr:  composable_expr.MUL composable_expr 
+	composable_expr:  composable_expr.DIV composable_expr 
+	composable_expr:  composable_expr.MOD composable_expr 
 
-	.  reduce 14 (src line 135)
+	OR  shift 31
+	AND  shift 32
+	LT  shift 33
+	GT  shift 34
+	EQ  shift 35
+	NE  shift 36
+	LE  shift 37
+	GE  shift 38
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 25 (src line 300)
 
 
 state 14
-	expr_block:  L_BRACE.statement_list R_BRACE 
-	statement_list: .    (2)
+	expr:  conditional_expr.    (26)
 
-	L_BRACE  shift 14
-	SEMICOLON  shift 7
-	NEWLINE  shift 8
-	LET  shift 16
-	IF  shift 15
-	RETURN  shift 17
-	NOOP  shift 9
-	.  reduce 2 (src line 83)
+	.  reduce 26 (src line 304)
 
-	statement_list  goto 20
-	nonempty_statement_list  goto 3
-	statement  goto 4
-	control_flow_expr  goto 6
-	expr_block  goto 10
-	conditional_expr  goto 11
-	assignment_expr  goto 12
-	return_expr  goto 13
-	terminator  goto 5
 
 state 15
+	assignment_expr:  LET.IDENT ASSIGN expr 
+
+	IDENT  shift 49
+	.  error
+
+
+state 16
+	return_expr:  RETURN.expr 
+	return_expr:  RETURN.AT IDENT expr 
+
+	L_BRACE  shift 28
+	AT  shift 51
+	IF  shift 20
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	expr  goto 50
+	unit_expr  goto 17
+	composable_expr  goto 13
+	expr_block  goto 27
+	conditional_expr  goto 14
+
+state 17
+	unit_expr:  unit_expr.DOT IDENT 
+	unit_expr:  unit_expr.L_PAREN argument_list R_PAREN 
+	composable_expr:  unit_expr.    (36)
+
+	L_PAREN  shift 53
+	DOT  shift 52
+	.  reduce 36 (src line 367)
+
+
+state 18
+	composable_expr:  SUB.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 54
+	expr_block  goto 27
+
+state 19
+	composable_expr:  NOT.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 55
+	expr_block  goto 27
+
+state 20
 	conditional_expr:  IF.composable_expr expr_block 
 	conditional_expr:  IF.composable_expr NEWLINE expr_block 
 	conditional_expr:  IF.composable_expr expr_block ELSE conditional_expr 
@@ -151,71 +268,548 @@ state 15
 	conditional_expr:  IF.composable_expr expr_block ELSE expr_block 
 	conditional_expr:  IF.composable_expr NEWLINE expr_block ELSE expr_block 
 
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
 	.  error
 
-	unit_expr  goto 22
-	composable_expr  goto 21
-	expr_block  goto 31
+	unit_expr  goto 17
+	composable_expr  goto 56
+	expr_block  goto 27
 
-state 16
-	assignment_expr:  LET.IDENT ASSIGN expr 
+state 21
+	expr_block:  IDENT.AT L_BRACE statement_list R_BRACE 
+	unit_expr:  IDENT.    (27)
 
-	IDENT  shift 33
-	.  error
+	AT  shift 57
+	.  reduce 27 (src line 310)
 
 
-state 17
-	return_expr:  RETURN.expr 
+state 22
+	unit_expr:  CHAR.    (28)
 
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	IF  shift 15
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
+	.  reduce 28 (src line 317)
 
-	expr  goto 34
-	unit_expr  goto 22
-	composable_expr  goto 35
-	expr_block  goto 31
-	conditional_expr  goto 36
 
-state 18
+state 23
+	unit_expr:  STRING.    (29)
+
+	.  reduce 29 (src line 323)
+
+
+state 24
+	unit_expr:  INT.    (30)
+
+	.  reduce 30 (src line 329)
+
+
+state 25
+	unit_expr:  FLOAT.    (31)
+
+	.  reduce 31 (src line 335)
+
+
+state 26
+	unit_expr:  BOOL.    (32)
+
+	.  reduce 32 (src line 341)
+
+
+state 27
+	unit_expr:  expr_block.    (33)
+
+	.  reduce 33 (src line 347)
+
+
+state 28
+	expr_block:  L_BRACE.statement_list R_BRACE 
+	statement_list: .    (2)
+
+	L_BRACE  shift 28
+	SEMICOLON  shift 7
+	NEWLINE  shift 8
+	LET  shift 15
+	IF  shift 20
+	RETURN  shift 16
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	NOOP  shift 9
+	.  reduce 2 (src line 83)
+
+	expr  goto 10
+	unit_expr  goto 17
+	composable_expr  goto 13
+	statement_list  goto 58
+	nonempty_statement_list  goto 3
+	statement  goto 4
+	control_flow_expr  goto 6
+	expr_block  goto 27
+	conditional_expr  goto 14
+	assignment_expr  goto 11
+	return_expr  goto 12
+	terminator  goto 5
+
+state 29
 	nonempty_statement_list:  nonempty_statement_list statement.    (5)
 
 	.  reduce 5 (src line 99)
 
 
-state 19
+state 30
 	statement:  control_flow_expr terminator.    (9)
 
-	.  reduce 9 (src line 115)
+	.  reduce 9 (src line 119)
 
 
-state 20
-	expr_block:  L_BRACE statement_list.R_BRACE 
+state 31
+	composable_expr:  composable_expr OR.composable_expr 
 
-	R_BRACE  shift 37
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 59
+	expr_block  goto 27
+
+state 32
+	composable_expr:  composable_expr AND.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 60
+	expr_block  goto 27
+
+state 33
+	composable_expr:  composable_expr LT.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 61
+	expr_block  goto 27
+
+state 34
+	composable_expr:  composable_expr GT.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 62
+	expr_block  goto 27
+
+state 35
+	composable_expr:  composable_expr EQ.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 63
+	expr_block  goto 27
+
+state 36
+	composable_expr:  composable_expr NE.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 64
+	expr_block  goto 27
+
+state 37
+	composable_expr:  composable_expr LE.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 65
+	expr_block  goto 27
+
+state 38
+	composable_expr:  composable_expr GE.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 66
+	expr_block  goto 27
+
+state 39
+	composable_expr:  composable_expr BITWISE_OR.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 67
+	expr_block  goto 27
+
+state 40
+	composable_expr:  composable_expr BITWISE_AND.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 68
+	expr_block  goto 27
+
+state 41
+	composable_expr:  composable_expr XOR.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 69
+	expr_block  goto 27
+
+state 42
+	composable_expr:  composable_expr L_SHIFT.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 70
+	expr_block  goto 27
+
+state 43
+	composable_expr:  composable_expr R_SHIFT.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 71
+	expr_block  goto 27
+
+state 44
+	composable_expr:  composable_expr ADD.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 72
+	expr_block  goto 27
+
+state 45
+	composable_expr:  composable_expr SUB.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 73
+	expr_block  goto 27
+
+state 46
+	composable_expr:  composable_expr MUL.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 74
+	expr_block  goto 27
+
+state 47
+	composable_expr:  composable_expr DIV.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 75
+	expr_block  goto 27
+
+state 48
+	composable_expr:  composable_expr MOD.composable_expr 
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	unit_expr  goto 17
+	composable_expr  goto 76
+	expr_block  goto 27
+
+state 49
+	assignment_expr:  LET IDENT.ASSIGN expr 
+
+	ASSIGN  shift 77
 	.  error
 
 
-state 21
+state 50
+	return_expr:  RETURN expr.    (23)
+
+	.  reduce 23 (src line 273)
+
+
+state 51
+	return_expr:  RETURN AT.IDENT expr 
+
+	IDENT  shift 78
+	.  error
+
+
+state 52
+	unit_expr:  unit_expr DOT.IDENT 
+
+	IDENT  shift 79
+	.  error
+
+
+state 53
+	unit_expr:  unit_expr L_PAREN.argument_list R_PAREN 
+	argument_list: .    (57)
+
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  reduce 57 (src line 611)
+
+	unit_expr  goto 17
+	composable_expr  goto 82
+	expr_block  goto 27
+	argument_list  goto 80
+	nonempty_argument_list  goto 81
+
+state 54
+	composable_expr:  composable_expr.OR composable_expr 
+	composable_expr:  composable_expr.AND composable_expr 
+	composable_expr:  composable_expr.LT composable_expr 
+	composable_expr:  composable_expr.GT composable_expr 
+	composable_expr:  composable_expr.EQ composable_expr 
+	composable_expr:  composable_expr.NE composable_expr 
+	composable_expr:  composable_expr.LE composable_expr 
+	composable_expr:  composable_expr.GE composable_expr 
+	composable_expr:  composable_expr.BITWISE_OR composable_expr 
+	composable_expr:  composable_expr.BITWISE_AND composable_expr 
+	composable_expr:  composable_expr.XOR composable_expr 
+	composable_expr:  composable_expr.L_SHIFT composable_expr 
+	composable_expr:  composable_expr.R_SHIFT composable_expr 
+	composable_expr:  composable_expr.ADD composable_expr 
+	composable_expr:  composable_expr.SUB composable_expr 
+	composable_expr:  composable_expr.MUL composable_expr 
+	composable_expr:  composable_expr.DIV composable_expr 
+	composable_expr:  composable_expr.MOD composable_expr 
+	composable_expr:  SUB composable_expr.    (55)
+
+	.  reduce 55 (src line 587)
+
+
+state 55
+	composable_expr:  composable_expr.OR composable_expr 
+	composable_expr:  composable_expr.AND composable_expr 
+	composable_expr:  composable_expr.LT composable_expr 
+	composable_expr:  composable_expr.GT composable_expr 
+	composable_expr:  composable_expr.EQ composable_expr 
+	composable_expr:  composable_expr.NE composable_expr 
+	composable_expr:  composable_expr.LE composable_expr 
+	composable_expr:  composable_expr.GE composable_expr 
+	composable_expr:  composable_expr.BITWISE_OR composable_expr 
+	composable_expr:  composable_expr.BITWISE_AND composable_expr 
+	composable_expr:  composable_expr.XOR composable_expr 
+	composable_expr:  composable_expr.L_SHIFT composable_expr 
+	composable_expr:  composable_expr.R_SHIFT composable_expr 
+	composable_expr:  composable_expr.ADD composable_expr 
+	composable_expr:  composable_expr.SUB composable_expr 
+	composable_expr:  composable_expr.MUL composable_expr 
+	composable_expr:  composable_expr.DIV composable_expr 
+	composable_expr:  composable_expr.MOD composable_expr 
+	composable_expr:  NOT composable_expr.    (56)
+
+	LT  shift 33
+	GT  shift 34
+	EQ  shift 35
+	NE  shift 36
+	LE  shift 37
+	GE  shift 38
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 56 (src line 598)
+
+
+state 56
 	conditional_expr:  IF composable_expr.expr_block 
 	conditional_expr:  IF composable_expr.NEWLINE expr_block 
 	conditional_expr:  IF composable_expr.expr_block ELSE conditional_expr 
@@ -241,746 +835,46 @@ state 21
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	L_BRACE  shift 14
-	NEWLINE  shift 39
-	OR  shift 40
-	AND  shift 41
-	LT  shift 42
-	GT  shift 43
-	EQ  shift 44
-	NE  shift 45
-	LE  shift 46
-	GE  shift 47
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
+	L_BRACE  shift 28
+	NEWLINE  shift 84
+	OR  shift 31
+	AND  shift 32
+	LT  shift 33
+	GT  shift 34
+	EQ  shift 35
+	NE  shift 36
+	LE  shift 37
+	GE  shift 38
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	IDENT  shift 85
 	.  error
 
-	expr_block  goto 38
-
-state 22
-	unit_expr:  unit_expr.DOT IDENT 
-	unit_expr:  unit_expr.L_PAREN argument_list R_PAREN 
-	composable_expr:  unit_expr.    (36)
-
-	L_PAREN  shift 59
-	DOT  shift 58
-	.  reduce 36 (src line 349)
-
-
-state 23
-	composable_expr:  SUB.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 60
-	expr_block  goto 31
-
-state 24
-	composable_expr:  NOT.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 61
-	expr_block  goto 31
-
-state 25
-	unit_expr:  IDENT.    (26)
-
-	.  reduce 26 (src line 280)
-
-
-state 26
-	unit_expr:  CHAR.    (27)
-
-	.  reduce 27 (src line 287)
-
-
-state 27
-	unit_expr:  STRING.    (28)
-
-	.  reduce 28 (src line 293)
-
-
-state 28
-	unit_expr:  INT.    (29)
-
-	.  reduce 29 (src line 299)
-
-
-state 29
-	unit_expr:  FLOAT.    (30)
-
-	.  reduce 30 (src line 305)
-
-
-state 30
-	unit_expr:  BOOL.    (31)
-
-	.  reduce 31 (src line 311)
-
-
-state 31
-	unit_expr:  expr_block.    (32)
-
-	.  reduce 32 (src line 317)
-
-
-state 32
-	unit_expr:  L_PAREN.composable_expr R_PAREN 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 62
-	expr_block  goto 31
-
-state 33
-	assignment_expr:  LET IDENT.ASSIGN expr 
-
-	ASSIGN  shift 63
-	.  error
-
-
-state 34
-	return_expr:  RETURN expr.    (23)
-
-	.  reduce 23 (src line 256)
-
-
-state 35
-	expr:  composable_expr.    (24)
-	composable_expr:  composable_expr.OR composable_expr 
-	composable_expr:  composable_expr.AND composable_expr 
-	composable_expr:  composable_expr.LT composable_expr 
-	composable_expr:  composable_expr.GT composable_expr 
-	composable_expr:  composable_expr.EQ composable_expr 
-	composable_expr:  composable_expr.NE composable_expr 
-	composable_expr:  composable_expr.LE composable_expr 
-	composable_expr:  composable_expr.GE composable_expr 
-	composable_expr:  composable_expr.BITWISE_OR composable_expr 
-	composable_expr:  composable_expr.BITWISE_AND composable_expr 
-	composable_expr:  composable_expr.XOR composable_expr 
-	composable_expr:  composable_expr.L_SHIFT composable_expr 
-	composable_expr:  composable_expr.R_SHIFT composable_expr 
-	composable_expr:  composable_expr.ADD composable_expr 
-	composable_expr:  composable_expr.SUB composable_expr 
-	composable_expr:  composable_expr.MUL composable_expr 
-	composable_expr:  composable_expr.DIV composable_expr 
-	composable_expr:  composable_expr.MOD composable_expr 
-
-	OR  shift 40
-	AND  shift 41
-	LT  shift 42
-	GT  shift 43
-	EQ  shift 44
-	NE  shift 45
-	LE  shift 46
-	GE  shift 47
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 24 (src line 270)
-
-
-state 36
-	expr:  conditional_expr.    (25)
-
-	.  reduce 25 (src line 274)
-
-
-state 37
-	expr_block:  L_BRACE statement_list R_BRACE.    (15)
-
-	.  reduce 15 (src line 141)
-
-
-state 38
-	conditional_expr:  IF composable_expr expr_block.    (16)
-	conditional_expr:  IF composable_expr expr_block.ELSE conditional_expr 
-	conditional_expr:  IF composable_expr expr_block.ELSE expr_block 
-
-	ELSE  shift 64
-	.  reduce 16 (src line 156)
-
-
-state 39
-	conditional_expr:  IF composable_expr NEWLINE.expr_block 
-	conditional_expr:  IF composable_expr NEWLINE.expr_block ELSE conditional_expr 
-	conditional_expr:  IF composable_expr NEWLINE.expr_block ELSE expr_block 
-
-	L_BRACE  shift 14
-	.  error
-
-	expr_block  goto 65
-
-state 40
-	composable_expr:  composable_expr OR.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 66
-	expr_block  goto 31
-
-state 41
-	composable_expr:  composable_expr AND.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 67
-	expr_block  goto 31
-
-state 42
-	composable_expr:  composable_expr LT.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 68
-	expr_block  goto 31
-
-state 43
-	composable_expr:  composable_expr GT.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 69
-	expr_block  goto 31
-
-state 44
-	composable_expr:  composable_expr EQ.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 70
-	expr_block  goto 31
-
-state 45
-	composable_expr:  composable_expr NE.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 71
-	expr_block  goto 31
-
-state 46
-	composable_expr:  composable_expr LE.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 72
-	expr_block  goto 31
-
-state 47
-	composable_expr:  composable_expr GE.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 73
-	expr_block  goto 31
-
-state 48
-	composable_expr:  composable_expr BITWISE_OR.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 74
-	expr_block  goto 31
-
-state 49
-	composable_expr:  composable_expr BITWISE_AND.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 75
-	expr_block  goto 31
-
-state 50
-	composable_expr:  composable_expr XOR.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 76
-	expr_block  goto 31
-
-state 51
-	composable_expr:  composable_expr L_SHIFT.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 77
-	expr_block  goto 31
-
-state 52
-	composable_expr:  composable_expr R_SHIFT.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 78
-	expr_block  goto 31
-
-state 53
-	composable_expr:  composable_expr ADD.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 79
-	expr_block  goto 31
-
-state 54
-	composable_expr:  composable_expr SUB.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 80
-	expr_block  goto 31
-
-state 55
-	composable_expr:  composable_expr MUL.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 81
-	expr_block  goto 31
-
-state 56
-	composable_expr:  composable_expr DIV.composable_expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	unit_expr  goto 22
-	composable_expr  goto 82
-	expr_block  goto 31
+	expr_block  goto 83
 
 state 57
-	composable_expr:  composable_expr MOD.composable_expr 
+	expr_block:  IDENT AT.L_BRACE statement_list R_BRACE 
 
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
+	L_BRACE  shift 86
 	.  error
 
-	unit_expr  goto 22
-	composable_expr  goto 83
-	expr_block  goto 31
 
 state 58
-	unit_expr:  unit_expr DOT.IDENT 
+	expr_block:  L_BRACE statement_list.R_BRACE 
 
-	IDENT  shift 84
+	R_BRACE  shift 87
 	.  error
 
 
 state 59
-	unit_expr:  unit_expr L_PAREN.argument_list R_PAREN 
-	argument_list: .    (57)
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  reduce 57 (src line 593)
-
-	unit_expr  goto 22
-	composable_expr  goto 87
-	expr_block  goto 31
-	argument_list  goto 85
-	nonempty_argument_list  goto 86
-
-state 60
-	composable_expr:  composable_expr.OR composable_expr 
-	composable_expr:  composable_expr.AND composable_expr 
-	composable_expr:  composable_expr.LT composable_expr 
-	composable_expr:  composable_expr.GT composable_expr 
-	composable_expr:  composable_expr.EQ composable_expr 
-	composable_expr:  composable_expr.NE composable_expr 
-	composable_expr:  composable_expr.LE composable_expr 
-	composable_expr:  composable_expr.GE composable_expr 
-	composable_expr:  composable_expr.BITWISE_OR composable_expr 
-	composable_expr:  composable_expr.BITWISE_AND composable_expr 
-	composable_expr:  composable_expr.XOR composable_expr 
-	composable_expr:  composable_expr.L_SHIFT composable_expr 
-	composable_expr:  composable_expr.R_SHIFT composable_expr 
-	composable_expr:  composable_expr.ADD composable_expr 
-	composable_expr:  composable_expr.SUB composable_expr 
-	composable_expr:  composable_expr.MUL composable_expr 
-	composable_expr:  composable_expr.DIV composable_expr 
-	composable_expr:  composable_expr.MOD composable_expr 
-	composable_expr:  SUB composable_expr.    (55)
-
-	.  reduce 55 (src line 569)
-
-
-state 61
-	composable_expr:  composable_expr.OR composable_expr 
-	composable_expr:  composable_expr.AND composable_expr 
-	composable_expr:  composable_expr.LT composable_expr 
-	composable_expr:  composable_expr.GT composable_expr 
-	composable_expr:  composable_expr.EQ composable_expr 
-	composable_expr:  composable_expr.NE composable_expr 
-	composable_expr:  composable_expr.LE composable_expr 
-	composable_expr:  composable_expr.GE composable_expr 
-	composable_expr:  composable_expr.BITWISE_OR composable_expr 
-	composable_expr:  composable_expr.BITWISE_AND composable_expr 
-	composable_expr:  composable_expr.XOR composable_expr 
-	composable_expr:  composable_expr.L_SHIFT composable_expr 
-	composable_expr:  composable_expr.R_SHIFT composable_expr 
-	composable_expr:  composable_expr.ADD composable_expr 
-	composable_expr:  composable_expr.SUB composable_expr 
-	composable_expr:  composable_expr.MUL composable_expr 
-	composable_expr:  composable_expr.DIV composable_expr 
-	composable_expr:  composable_expr.MOD composable_expr 
-	composable_expr:  NOT composable_expr.    (56)
-
-	LT  shift 42
-	GT  shift 43
-	EQ  shift 44
-	NE  shift 45
-	LE  shift 46
-	GE  shift 47
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 56 (src line 580)
-
-
-state 62
-	unit_expr:  L_PAREN composable_expr.R_PAREN 
-	composable_expr:  composable_expr.OR composable_expr 
-	composable_expr:  composable_expr.AND composable_expr 
-	composable_expr:  composable_expr.LT composable_expr 
-	composable_expr:  composable_expr.GT composable_expr 
-	composable_expr:  composable_expr.EQ composable_expr 
-	composable_expr:  composable_expr.NE composable_expr 
-	composable_expr:  composable_expr.LE composable_expr 
-	composable_expr:  composable_expr.GE composable_expr 
-	composable_expr:  composable_expr.BITWISE_OR composable_expr 
-	composable_expr:  composable_expr.BITWISE_AND composable_expr 
-	composable_expr:  composable_expr.XOR composable_expr 
-	composable_expr:  composable_expr.L_SHIFT composable_expr 
-	composable_expr:  composable_expr.R_SHIFT composable_expr 
-	composable_expr:  composable_expr.ADD composable_expr 
-	composable_expr:  composable_expr.SUB composable_expr 
-	composable_expr:  composable_expr.MUL composable_expr 
-	composable_expr:  composable_expr.DIV composable_expr 
-	composable_expr:  composable_expr.MOD composable_expr 
-
-	R_PAREN  shift 88
-	OR  shift 40
-	AND  shift 41
-	LT  shift 42
-	GT  shift 43
-	EQ  shift 44
-	NE  shift 45
-	LE  shift 46
-	GE  shift 47
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  error
-
-
-state 63
-	assignment_expr:  LET IDENT ASSIGN.expr 
-
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	IF  shift 15
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
-	.  error
-
-	expr  goto 89
-	unit_expr  goto 22
-	composable_expr  goto 35
-	expr_block  goto 31
-	conditional_expr  goto 36
-
-state 64
-	conditional_expr:  IF composable_expr expr_block ELSE.conditional_expr 
-	conditional_expr:  IF composable_expr expr_block ELSE.expr_block 
-
-	L_BRACE  shift 14
-	IF  shift 15
-	.  error
-
-	expr_block  goto 91
-	conditional_expr  goto 90
-
-state 65
-	conditional_expr:  IF composable_expr NEWLINE expr_block.    (17)
-	conditional_expr:  IF composable_expr NEWLINE expr_block.ELSE conditional_expr 
-	conditional_expr:  IF composable_expr NEWLINE expr_block.ELSE expr_block 
-
-	ELSE  shift 92
-	.  reduce 17 (src line 169)
-
-
-state 66
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr OR composable_expr.    (37)
 	composable_expr:  composable_expr.AND composable_expr 
@@ -1001,27 +895,27 @@ state 66
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	AND  shift 41
-	LT  shift 42
-	GT  shift 43
-	EQ  shift 44
-	NE  shift 45
-	LE  shift 46
-	GE  shift 47
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 37 (src line 353)
+	AND  shift 32
+	LT  shift 33
+	GT  shift 34
+	EQ  shift 35
+	NE  shift 36
+	LE  shift 37
+	GE  shift 38
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 37 (src line 371)
 
 
-state 67
+state 60
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr AND composable_expr.    (38)
@@ -1042,26 +936,26 @@ state 67
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	LT  shift 42
-	GT  shift 43
-	EQ  shift 44
-	NE  shift 45
-	LE  shift 46
-	GE  shift 47
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 38 (src line 365)
+	LT  shift 33
+	GT  shift 34
+	EQ  shift 35
+	NE  shift 36
+	LE  shift 37
+	GE  shift 38
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 38 (src line 383)
 
 
-state 68
+state 61
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1082,20 +976,20 @@ state 68
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 39 (src line 377)
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 39 (src line 395)
 
 
-state 69
+state 62
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1116,20 +1010,20 @@ state 69
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 40 (src line 389)
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 40 (src line 407)
 
 
-state 70
+state 63
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1150,20 +1044,20 @@ state 70
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 41 (src line 401)
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 41 (src line 419)
 
 
-state 71
+state 64
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1184,20 +1078,20 @@ state 71
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 42 (src line 413)
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 42 (src line 431)
 
 
-state 72
+state 65
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1218,20 +1112,20 @@ state 72
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 43 (src line 425)
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 43 (src line 443)
 
 
-state 73
+state 66
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1252,20 +1146,20 @@ state 73
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 44 (src line 437)
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 44 (src line 455)
 
 
-state 74
+state 67
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1286,19 +1180,19 @@ state 74
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 45 (src line 449)
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 45 (src line 467)
 
 
-state 75
+state 68
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1319,18 +1213,18 @@ state 75
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 46 (src line 461)
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 46 (src line 479)
 
 
-state 76
+state 69
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1351,17 +1245,17 @@ state 76
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 47 (src line 473)
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 47 (src line 491)
 
 
-state 77
+state 70
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1382,15 +1276,15 @@ state 77
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 48 (src line 485)
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 48 (src line 503)
 
 
-state 78
+state 71
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1411,15 +1305,15 @@ state 78
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 49 (src line 497)
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 49 (src line 515)
 
 
-state 79
+state 72
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1440,13 +1334,13 @@ state 79
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 50 (src line 509)
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 50 (src line 527)
 
 
-state 80
+state 73
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1467,13 +1361,13 @@ state 80
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 51 (src line 521)
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 51 (src line 539)
 
 
-state 81
+state 74
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1494,10 +1388,10 @@ state 81
 	composable_expr:  composable_expr.DIV composable_expr 
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	.  reduce 52 (src line 533)
+	.  reduce 52 (src line 551)
 
 
-state 82
+state 75
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1518,10 +1412,10 @@ state 82
 	composable_expr:  composable_expr DIV composable_expr.    (53)
 	composable_expr:  composable_expr.MOD composable_expr 
 
-	.  reduce 53 (src line 545)
+	.  reduce 53 (src line 563)
 
 
-state 83
+state 76
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1542,31 +1436,73 @@ state 83
 	composable_expr:  composable_expr.MOD composable_expr 
 	composable_expr:  composable_expr MOD composable_expr.    (54)
 
-	.  reduce 54 (src line 557)
+	.  reduce 54 (src line 575)
 
 
-state 84
-	unit_expr:  unit_expr DOT IDENT.    (33)
+state 77
+	assignment_expr:  LET IDENT ASSIGN.expr 
 
-	.  reduce 33 (src line 320)
+	L_BRACE  shift 28
+	IF  shift 20
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	expr  goto 88
+	unit_expr  goto 17
+	composable_expr  goto 13
+	expr_block  goto 27
+	conditional_expr  goto 14
+
+state 78
+	return_expr:  RETURN AT IDENT.expr 
+
+	L_BRACE  shift 28
+	IF  shift 20
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	.  error
+
+	expr  goto 89
+	unit_expr  goto 17
+	composable_expr  goto 13
+	expr_block  goto 27
+	conditional_expr  goto 14
+
+state 79
+	unit_expr:  unit_expr DOT IDENT.    (34)
+
+	.  reduce 34 (src line 350)
 
 
-state 85
+state 80
 	unit_expr:  unit_expr L_PAREN argument_list.R_PAREN 
 
-	R_PAREN  shift 93
+	R_PAREN  shift 90
 	.  error
 
 
-state 86
+state 81
 	argument_list:  nonempty_argument_list.    (58)
 	nonempty_argument_list:  nonempty_argument_list.COMMA composable_expr 
 
-	COMMA  shift 94
-	.  reduce 58 (src line 596)
+	COMMA  shift 91
+	.  reduce 58 (src line 614)
 
 
-state 87
+state 82
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1587,100 +1523,159 @@ state 87
 	composable_expr:  composable_expr.MOD composable_expr 
 	nonempty_argument_list:  composable_expr.    (59)
 
-	OR  shift 40
-	AND  shift 41
-	LT  shift 42
-	GT  shift 43
-	EQ  shift 44
-	NE  shift 45
-	LE  shift 46
-	GE  shift 47
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 59 (src line 600)
+	OR  shift 31
+	AND  shift 32
+	LT  shift 33
+	GT  shift 34
+	EQ  shift 35
+	NE  shift 36
+	LE  shift 37
+	GE  shift 38
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 59 (src line 619)
+
+
+state 83
+	conditional_expr:  IF composable_expr expr_block.    (16)
+	conditional_expr:  IF composable_expr expr_block.ELSE conditional_expr 
+	conditional_expr:  IF composable_expr expr_block.ELSE expr_block 
+
+	ELSE  shift 92
+	.  reduce 16 (src line 174)
+
+
+state 84
+	conditional_expr:  IF composable_expr NEWLINE.expr_block 
+	conditional_expr:  IF composable_expr NEWLINE.expr_block ELSE conditional_expr 
+	conditional_expr:  IF composable_expr NEWLINE.expr_block ELSE expr_block 
+
+	L_BRACE  shift 28
+	IDENT  shift 85
+	.  error
+
+	expr_block  goto 93
+
+state 85
+	expr_block:  IDENT.AT L_BRACE statement_list R_BRACE 
+
+	AT  shift 57
+	.  error
+
+
+state 86
+	expr_block:  IDENT AT L_BRACE.statement_list R_BRACE 
+	statement_list: .    (2)
+
+	L_BRACE  shift 28
+	SEMICOLON  shift 7
+	NEWLINE  shift 8
+	LET  shift 15
+	IF  shift 20
+	RETURN  shift 16
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
+	NOOP  shift 9
+	.  reduce 2 (src line 83)
+
+	expr  goto 10
+	unit_expr  goto 17
+	composable_expr  goto 13
+	statement_list  goto 94
+	nonempty_statement_list  goto 3
+	statement  goto 4
+	control_flow_expr  goto 6
+	expr_block  goto 27
+	conditional_expr  goto 14
+	assignment_expr  goto 11
+	return_expr  goto 12
+	terminator  goto 5
+
+state 87
+	expr_block:  L_BRACE statement_list R_BRACE.    (14)
+
+	.  reduce 14 (src line 145)
 
 
 state 88
-	unit_expr:  L_PAREN composable_expr R_PAREN.    (35)
+	assignment_expr:  LET IDENT ASSIGN expr.    (22)
 
-	.  reduce 35 (src line 334)
+	.  reduce 22 (src line 257)
 
 
 state 89
-	assignment_expr:  LET IDENT ASSIGN expr.    (22)
+	return_expr:  RETURN AT IDENT expr.    (24)
 
-	.  reduce 22 (src line 239)
+	.  reduce 24 (src line 285)
 
 
 state 90
-	conditional_expr:  IF composable_expr expr_block ELSE conditional_expr.    (18)
+	unit_expr:  unit_expr L_PAREN argument_list R_PAREN.    (35)
 
-	.  reduce 18 (src line 181)
+	.  reduce 35 (src line 362)
 
 
 state 91
-	conditional_expr:  IF composable_expr expr_block ELSE expr_block.    (20)
+	nonempty_argument_list:  nonempty_argument_list COMMA.composable_expr 
 
-	.  reduce 20 (src line 209)
-
-
-state 92
-	conditional_expr:  IF composable_expr NEWLINE expr_block ELSE.conditional_expr 
-	conditional_expr:  IF composable_expr NEWLINE expr_block ELSE.expr_block 
-
-	L_BRACE  shift 14
-	IF  shift 15
+	L_BRACE  shift 28
+	NOT  shift 19
+	SUB  shift 18
+	IDENT  shift 21
+	CHAR  shift 22
+	STRING  shift 23
+	INT  shift 24
+	FLOAT  shift 25
+	BOOL  shift 26
 	.  error
 
-	expr_block  goto 96
-	conditional_expr  goto 95
+	unit_expr  goto 17
+	composable_expr  goto 95
+	expr_block  goto 27
+
+state 92
+	conditional_expr:  IF composable_expr expr_block ELSE.conditional_expr 
+	conditional_expr:  IF composable_expr expr_block ELSE.expr_block 
+
+	L_BRACE  shift 28
+	IF  shift 20
+	IDENT  shift 85
+	.  error
+
+	expr_block  goto 97
+	conditional_expr  goto 96
 
 state 93
-	unit_expr:  unit_expr L_PAREN argument_list R_PAREN.    (34)
+	conditional_expr:  IF composable_expr NEWLINE expr_block.    (17)
+	conditional_expr:  IF composable_expr NEWLINE expr_block.ELSE conditional_expr 
+	conditional_expr:  IF composable_expr NEWLINE expr_block.ELSE expr_block 
 
-	.  reduce 34 (src line 332)
+	ELSE  shift 98
+	.  reduce 17 (src line 187)
 
 
 state 94
-	nonempty_argument_list:  nonempty_argument_list COMMA.composable_expr 
+	expr_block:  IDENT AT L_BRACE statement_list.R_BRACE 
 
-	L_BRACE  shift 14
-	L_PAREN  shift 32
-	NOT  shift 24
-	SUB  shift 23
-	IDENT  shift 25
-	CHAR  shift 26
-	STRING  shift 27
-	INT  shift 28
-	FLOAT  shift 29
-	BOOL  shift 30
+	R_BRACE  shift 99
 	.  error
 
-	unit_expr  goto 22
-	composable_expr  goto 97
-	expr_block  goto 31
 
 state 95
-	conditional_expr:  IF composable_expr NEWLINE expr_block ELSE conditional_expr.    (19)
-
-	.  reduce 19 (src line 195)
-
-
-state 96
-	conditional_expr:  IF composable_expr NEWLINE expr_block ELSE expr_block.    (21)
-
-	.  reduce 21 (src line 223)
-
-
-state 97
 	composable_expr:  composable_expr.OR composable_expr 
 	composable_expr:  composable_expr.AND composable_expr 
 	composable_expr:  composable_expr.LT composable_expr 
@@ -1701,36 +1696,78 @@ state 97
 	composable_expr:  composable_expr.MOD composable_expr 
 	nonempty_argument_list:  nonempty_argument_list COMMA composable_expr.    (60)
 
-	OR  shift 40
-	AND  shift 41
-	LT  shift 42
-	GT  shift 43
-	EQ  shift 44
-	NE  shift 45
-	LE  shift 46
-	GE  shift 47
-	BITWISE_OR  shift 48
-	BITWISE_AND  shift 49
-	XOR  shift 50
-	L_SHIFT  shift 51
-	R_SHIFT  shift 52
-	ADD  shift 53
-	SUB  shift 54
-	MUL  shift 55
-	DIV  shift 56
-	MOD  shift 57
-	.  reduce 60 (src line 603)
+	OR  shift 31
+	AND  shift 32
+	LT  shift 33
+	GT  shift 34
+	EQ  shift 35
+	NE  shift 36
+	LE  shift 37
+	GE  shift 38
+	BITWISE_OR  shift 39
+	BITWISE_AND  shift 40
+	XOR  shift 41
+	L_SHIFT  shift 42
+	R_SHIFT  shift 43
+	ADD  shift 44
+	SUB  shift 45
+	MUL  shift 46
+	DIV  shift 47
+	MOD  shift 48
+	.  reduce 60 (src line 623)
 
 
-50 terminals, 16 nonterminals
-61 grammar rules, 98/8000 states
+state 96
+	conditional_expr:  IF composable_expr expr_block ELSE conditional_expr.    (18)
+
+	.  reduce 18 (src line 199)
+
+
+state 97
+	conditional_expr:  IF composable_expr expr_block ELSE expr_block.    (20)
+
+	.  reduce 20 (src line 227)
+
+
+state 98
+	conditional_expr:  IF composable_expr NEWLINE expr_block ELSE.conditional_expr 
+	conditional_expr:  IF composable_expr NEWLINE expr_block ELSE.expr_block 
+
+	L_BRACE  shift 28
+	IF  shift 20
+	IDENT  shift 85
+	.  error
+
+	expr_block  goto 101
+	conditional_expr  goto 100
+
+state 99
+	expr_block:  IDENT AT L_BRACE statement_list R_BRACE.    (15)
+
+	.  reduce 15 (src line 158)
+
+
+state 100
+	conditional_expr:  IF composable_expr NEWLINE expr_block ELSE conditional_expr.    (19)
+
+	.  reduce 19 (src line 213)
+
+
+state 101
+	conditional_expr:  IF composable_expr NEWLINE expr_block ELSE expr_block.    (21)
+
+	.  reduce 21 (src line 241)
+
+
+51 terminals, 16 nonterminals
+61 grammar rules, 102/8000 states
 0 shift/reduce, 0 reduce/reduce conflicts reported
 65 working sets used
-memory: parser 131/120000
-67 extra closures
-542 shift entries, 1 exceptions
-54 goto entries
-63 entries saved by goto default
-Optimizer space used: output 259/120000
-259 table entries, 30 zero
-maximum spread: 50, maximum offset: 94
+memory: parser 166/120000
+68 extra closures
+547 shift entries, 1 exceptions
+51 goto entries
+89 entries saved by goto default
+Optimizer space used: output 244/120000
+244 table entries, 13 zero
+maximum spread: 51, maximum offset: 98

--- a/parser/raw_tokenizer.go
+++ b/parser/raw_tokenizer.go
@@ -120,7 +120,9 @@ var (
 		'[': parseSymbol(map[string]int{"[": L_BRACKET}),
 		']': parseSymbol(map[string]int{"]": R_BRACKET}),
 
-		// Unused leading characters: @ # $ ~ ` ? \
+		'@': parseSymbol(map[string]int{"@": AT}),
+
+		// Unused leading characters: # $ ~ ` ? \
 
 		// NOTE(patrick): ' ' and '\t' are ignored
 	}
@@ -172,7 +174,8 @@ func parseIdentifierOrKeyword(tok *rawTokenizer) (*Token, error) {
 
 		if !(('a' <= char && char <= 'z') ||
 			('A' <= char && char <= 'Z') ||
-			'_' == char) {
+			'_' == char ||
+			'0' <= char && char <= '9') {
 
 			break
 		}

--- a/parser/terminator_processor.go
+++ b/parser/terminator_processor.go
@@ -22,7 +22,6 @@ var (
 		LET:     struct{}{},
 		IF:      struct{}{},
 		RETURN:  struct{}{},
-		L_PAREN: struct{}{}, // invocation vs expression grouping
 		L_BRACE: struct{}{}, // expression block needs special parser handling
 		R_BRACE: struct{}{}, // ensures statement terminates
 	}


### PR DESCRIPTION
* add labels to expr block
* add labels return
* remove (<expr>) since {<expr>} work just as well
* allow stand alone expression as statement